### PR TITLE
Fix parsing messages of type ERROR (StompClient: Error parsing message - java.util.NoSuchElementException)

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/dto/StompMessage.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/dto/StompMessage.java
@@ -86,7 +86,9 @@ public class StompMessage {
             headers.add(new StompHeader(matcher.group(1), matcher.group(2)));
         }
 
-        reader.skip("\n\n");
+        if (reader.hasNext("\n\n")) {
+            reader.skip("\n\n");
+        }
 
         reader.useDelimiter(TERMINATE_MESSAGE_SYMBOL);
         String payload = reader.hasNext() ? reader.next() : null;


### PR DESCRIPTION
There should be a check that we have two empty lines in the message.